### PR TITLE
fix: React dom error caused by missing return in LiquidationAlert

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -44,11 +44,18 @@ function Main() {
   }, [invitationActiveState, keyring, accountAddress]);
 
   useEffect(() => {
-    const interval = setInterval(async () => {
-      if (accountAddress && invitationActiveState === 'Activated' && api) {
+    let interval = null;
+    console.log(
+      'before condition: ' + invitationActiveState + ' ' + accountAddress
+    );
+    if (accountAddress && invitationActiveState === 'Activated' && api) {
+      interval = setInterval(async () => {
+        console.log(
+          'wow, fetch user info:' + invitationActiveState + ' ' + accountAddress
+        );
         fetchUserInfo(setAccountBalance, accountAddress);
-      }
-    }, 3000);
+      }, 3000);
+    }
 
     return () => clearInterval(interval);
   }, [api, accountAddress, invitationActiveState]);

--- a/src/components/Liquidation/LiquidationAlert.js
+++ b/src/components/Liquidation/LiquidationAlert.js
@@ -2,26 +2,34 @@ import React from 'react';
 
 import './LiquidationAlert.scss';
 
-export default function Main (props) {
+export default function Main(props) {
   const { accountPair, accountBalance, liquidationThreshold } = props;
 
   if (!accountPair || !accountPair.address) {
     return null;
   }
 
-  if (accountBalance.borrowLimit == null ||
-      accountBalance.debtBalance == null ||
-      liquidationThreshold == null) {
+  if (
+    accountBalance.borrowLimit == null ||
+    accountBalance.debtBalance == null ||
+    liquidationThreshold == null
+  ) {
     return null;
   }
 
-  if (accountBalance.debtBalance > accountBalance.borrowLimit / liquidationThreshold) {
+  if (
+    accountBalance.debtBalance >
+    accountBalance.borrowLimit / liquidationThreshold
+  ) {
     return (
       <div className="LiquidationAlert-container">
         <p className="LiquidationAlert-warning-text">
-          Warning. Your account is being liquidated. Please repay as soon as possible.
+          Warning. Your account is being liquidated. Please repay as soon as
+          possible.
         </p>
       </div>
     );
   }
+
+  return null;
 }


### PR DESCRIPTION
fix: React dom error caused by missing return in LiquidationAlert

- Setting getUserInfo interval request when condition is triggered.
- Return null by default in LiquidationAlert component.